### PR TITLE
Replace `*` with explicit `Type` kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work/
 *~
 /stack.yaml.lock
+dist-newstyle

--- a/src/Database/Redis/Schema/Lock.hs
+++ b/src/Database/Redis/Schema/Lock.hs
@@ -28,6 +28,7 @@ module Database.Redis.Schema.Lock
 
 import GHC.Generics
 import Data.Functor     ( void )
+import Data.Kind        ( Type )
 import Data.Maybe       ( fromMaybe )
 import Data.Time        ( NominalDiffTime, addUTCTime, getCurrentTime )
 import Data.Set         ( Set )
@@ -149,12 +150,12 @@ instance Redis.Serializable LockSharing where
   fromBS _ = Nothing
 instance Redis.SimpleValue inst LockSharing
 
-data LockFieldName :: * -> * where
+data LockFieldName :: Type -> Type where
   LockFieldSharing :: LockFieldName LockSharing
   LockFieldOwners  :: LockFieldName (Set LockOwnerId)
 
 -- Ref that points to the components of a shareable lock.
-data LockField :: * -> * -> * where
+data LockField :: Type -> Type -> Type where
   LockField :: ByteString -> LockFieldName ty -> LockField inst ty
 
 instance Redis.Value inst ty => Redis.Ref (LockField inst ty) where


### PR DESCRIPTION
- [X] Fixes compilation errors from GHC 9.2.4.
- [X] Also tested with GHC 8.10.7.