### PR TITLE
Update some tool versions used in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1
         with:
-          ghc-version: "8.10.7"  # current version used at Chordify
+          ghc-version: "9.4.8"  # current version used at Chordify
           enable-stack: true
           stack-version: "latest"
       - run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.4"] # "9.4.2"
-        cabal: ["3.6.2.0"]
+        ghc: ["8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.4"]
+        cabal: ["3.10.2.1"]
         os: [ubuntu-latest, macOS-latest]
     name: build and test (cabal)
     steps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-18.23
+resolver: lts-21.25
 extra-deps:
   - monadIO-0.11.1.0@sha256:2407c8aee3a74f3eba897f7c87f702f502394aec8cd412f3d2334cc353f54f13,964


### PR DESCRIPTION
This means we no longer guarantee support for GHC versions older than 8.10.7. I think this is acceptable.