### PR TITLE
fix: throw on failed bytestring parsing

### DIFF
--- a/src/Database/Redis/Schema.hs
+++ b/src/Database/Redis/Schema.hs
@@ -368,9 +368,9 @@ class Value inst val where
 
   default valGet :: SimpleValue inst val => Identifier val -> RedisM inst (Maybe val)
   valGet (SviTopLevel keyBS) =
-    fmap (fromBS =<<) . expectRight "valGet/plain" =<< Hedis.get keyBS
+    (traverse fromBSorThrow <=< expectRight "valGet/plain") =<< Hedis.get keyBS
   valGet (SviHash keyBS hkeyBS) =
-    fmap (fromBS =<<) . expectRight "valGet/hash" =<< Hedis.hget keyBS hkeyBS
+    (traverse fromBSorThrow <=< expectRight "valGet/hash") =<< Hedis.hget keyBS hkeyBS
 
   -- | Write a value.
   valSet :: Identifier val -> val -> RedisM inst ()
@@ -399,6 +399,10 @@ class Value inst val where
     expectRight "valSetTTLIfExists/plain" =<< Hedis.expire keyBS ttlSec
   valSetTTLIfExists (SviHash keyBS _hkeyBS) (TTLSec ttlSec) =
     expectRight "valSetTTLIfExists/hash" =<< Hedis.expire keyBS ttlSec
+
+-- | Ensure the fromBS conversation does not fail silently due to a change of the internal Haskell ValueType of a Ref
+fromBSorThrow :: Serializable a => ByteString -> RedisM inst a
+fromBSorThrow bs = maybe (throw $ CouldNotDecodeValue $ Just bs) pure $ fromBS bs
 
 data SimpleValueIdentifier
   = SviTopLevel ByteString         -- ^ Stored in a top-level key.

--- a/src/Database/Redis/Schema.hs
+++ b/src/Database/Redis/Schema.hs
@@ -332,8 +332,8 @@ class Value inst val where
   txValGet :: Identifier val -> Tx inst (Maybe val)
 
   default txValGet :: SimpleValue inst val => Identifier val -> Tx inst (Maybe val)
-  txValGet (SviTopLevel keyBS) = fmap (fromBS =<<) . txWrap $ Hedis.get keyBS
-  txValGet (SviHash keyBS hkeyBS) = fmap (fromBS =<<) . txWrap $ Hedis.hget keyBS hkeyBS
+  txValGet (SviTopLevel keyBS) = txFromBSorExcept $ txWrap $ Hedis.get keyBS
+  txValGet (SviHash keyBS hkeyBS) = txFromBSorExcept $ txWrap $ Hedis.hget keyBS hkeyBS
 
   -- | Write a value to Redis in a transaction.
   txValSet :: Identifier val -> val -> Tx inst ()
@@ -368,9 +368,9 @@ class Value inst val where
 
   default valGet :: SimpleValue inst val => Identifier val -> RedisM inst (Maybe val)
   valGet (SviTopLevel keyBS) =
-    (traverse fromBSorThrow <=< expectRight "valGet/plain") =<< Hedis.get keyBS
+    (traverse rFromBSorThrow <=< expectRight "valGet/plain") =<< Hedis.get keyBS
   valGet (SviHash keyBS hkeyBS) =
-    (traverse fromBSorThrow <=< expectRight "valGet/hash") =<< Hedis.hget keyBS hkeyBS
+    (traverse rFromBSorThrow <=< expectRight "valGet/hash") =<< Hedis.hget keyBS hkeyBS
 
   -- | Write a value.
   valSet :: Identifier val -> val -> RedisM inst ()
@@ -401,8 +401,14 @@ class Value inst val where
     expectRight "valSetTTLIfExists/hash" =<< Hedis.expire keyBS ttlSec
 
 -- | Ensure the fromBS conversation does not fail silently due to a change of the internal Haskell ValueType of a Ref
-fromBSorThrow :: Serializable a => ByteString -> RedisM inst a
-fromBSorThrow bs = maybe (throw $ CouldNotDecodeValue $ Just bs) pure $ fromBS bs
+rFromBSorThrow :: Serializable a => ByteString -> RedisM inst a
+rFromBSorThrow bs = maybe (throw $ CouldNotDecodeValue $ Just bs) pure $ fromBS bs
+
+txFromBSorExcept :: Serializable a => Tx inst (Maybe ByteString) -> Tx inst (Maybe a)
+txFromBSorExcept = txCheckMap $ traverse $ maybeToEither . CouldNotDecodeValue . Just <*> fromBS
+  where
+    maybeToEither _ (Just b) = Right b
+    maybeToEither a Nothing = Left a
 
 data SimpleValueIdentifier
   = SviTopLevel ByteString         -- ^ Stored in a top-level key.
@@ -455,7 +461,7 @@ txTake ref = txGet ref <* txDelete_ ref
 getSet :: forall ref. SimpleRef ref => ref -> ValueType ref -> RedisM (RefInstance ref) (Maybe (ValueType ref))
 getSet ref val = case toIdentifier ref of
   SviTopLevel keyBS ->
-    traverse fromBSorThrow
+    traverse rFromBSorThrow
     =<< expectRight "getSet/plain"
     =<< Hedis.getset keyBS (toBS val)
 
@@ -874,14 +880,14 @@ lPopRight :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref
 lPopRight (toIdentifier -> keyBS) =
   Redis (Hedis.rpop keyBS)
   >>= expectRight "rpop"
-  >>= traverse fromBSorThrow
+  >>= traverse rFromBSorThrow
 
 -- | Pop from the right, blocking.
 lPopRightBlocking :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => TTL -> ref -> RedisM (RefInstance ref) (Maybe a)
 lPopRightBlocking (TTLSec timeoutSec) (toIdentifier -> keyBS) =
   Redis (Hedis.brpop [keyBS] timeoutSec)
     >>= expectRight "brpop"
-    >>= traverse (fromBSorThrow . snd)
+    >>= traverse (rFromBSorThrow . snd)
 
 -- | Delete from a Redis list
 lRem :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> Integer -> a -> RedisM (RefInstance ref) ()

--- a/src/Database/Redis/Schema.hs
+++ b/src/Database/Redis/Schema.hs
@@ -455,8 +455,9 @@ txTake ref = txGet ref <* txDelete_ ref
 getSet :: forall ref. SimpleRef ref => ref -> ValueType ref -> RedisM (RefInstance ref) (Maybe (ValueType ref))
 getSet ref val = case toIdentifier ref of
   SviTopLevel keyBS ->
-    fmap (fromBS =<<) . expectRight "getSet/plain"
-      =<< Hedis.getset keyBS (toBS val)
+    traverse fromBSorThrow
+    =<< expectRight "getSet/plain"
+    =<< Hedis.getset keyBS (toBS val)
 
   -- no native Redis call for this
   SviHash _ _ -> atomically (txGet ref <* txSet ref val)
@@ -872,19 +873,15 @@ lPushLeft (toIdentifier -> keyBS) vals =
 lPopRight :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> RedisM (RefInstance ref) (Maybe a)
 lPopRight (toIdentifier -> keyBS) =
   Redis (Hedis.rpop keyBS)
-  >>= fmap (fromBS =<<) . expectRight "rpop"
+  >>= expectRight "rpop"
+  >>= traverse fromBSorThrow
 
 -- | Pop from the right, blocking.
 lPopRightBlocking :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => TTL -> ref -> RedisM (RefInstance ref) (Maybe a)
 lPopRightBlocking (TTLSec timeoutSec) (toIdentifier -> keyBS) =
   Redis (Hedis.brpop [keyBS] timeoutSec)
     >>= expectRight "brpop"
-    >>= \case
-      Nothing -> pure Nothing -- timeout
-      Just (_listName, valBS) ->
-        case fromBS valBS of
-          Just val -> pure $ Just val
-          Nothing -> throw $ CouldNotDecodeValue (Just valBS)
+    >>= traverse (fromBSorThrow . snd)
 
 -- | Delete from a Redis list
 lRem :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> Integer -> a -> RedisM (RefInstance ref) ()

--- a/src/Database/Redis/Schema.hs
+++ b/src/Database/Redis/Schema.hs
@@ -368,9 +368,9 @@ class Value inst val where
 
   default valGet :: SimpleValue inst val => Identifier val -> RedisM inst (Maybe val)
   valGet (SviTopLevel keyBS) =
-    (traverse rFromBSorThrow <=< expectRight "valGet/plain") =<< Hedis.get keyBS
+    traverse rFromBSorThrow =<< expectRight "valGet/plain" =<< Hedis.get keyBS
   valGet (SviHash keyBS hkeyBS) =
-    (traverse rFromBSorThrow <=< expectRight "valGet/hash") =<< Hedis.hget keyBS hkeyBS
+    traverse rFromBSorThrow =<< expectRight "valGet/hash" =<< Hedis.hget keyBS hkeyBS
 
   -- | Write a value.
   valSet :: Identifier val -> val -> RedisM inst ()
@@ -400,15 +400,12 @@ class Value inst val where
   valSetTTLIfExists (SviHash keyBS _hkeyBS) (TTLSec ttlSec) =
     expectRight "valSetTTLIfExists/hash" =<< Hedis.expire keyBS ttlSec
 
--- | Ensure the fromBS conversation does not fail silently due to a change of the internal Haskell ValueType of a Ref
+-- | Ensure the fromBS conversion does not fail silently due to a change of the internal Haskell ValueType of a Ref
 rFromBSorThrow :: Serializable a => ByteString -> RedisM inst a
 rFromBSorThrow bs = maybe (throw $ CouldNotDecodeValue $ Just bs) pure $ fromBS bs
 
 txFromBSorExcept :: Serializable a => Tx inst (Maybe ByteString) -> Tx inst (Maybe a)
-txFromBSorExcept = txCheckMap $ traverse $ maybeToEither . CouldNotDecodeValue . Just <*> fromBS
-  where
-    maybeToEither _ (Just b) = Right b
-    maybeToEither a Nothing = Left a
+txFromBSorExcept = txCheckMap $ traverse $ \bs -> maybe (Left $ CouldNotDecodeValue $ Just bs) Right $ fromBS bs
 
 data SimpleValueIdentifier
   = SviTopLevel ByteString         -- ^ Stored in a top-level key.


### PR DESCRIPTION
This closes internal issue #1706
The functional application order is sometimes different but I just stuck to what was already there.
I hope the solutions aren't too pointfree

Original issue summary:

Currently, Database.Redis.Schema joins the Maybe from `fromBS` and get into a single one; meaning that if something fails in Serialization, it is observed as if the key doesn't exists. We currently know this `readBinary` can (and does) fail on some entries. We don't know which shape these have. But at least the current form of [...] should work on some entries as well? At least prior all failed.