### PR TITLE
Support `hedis-0.16` 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ["8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.4"]
-        cabal: ["3.10.2.1"]
+        ghc: ["9.6.4", "9.8.4", "9.10.3", "9.12.4"]
+        cabal: ["3.16.0.0"]
         os: [ubuntu-latest, macOS-latest]
     name: build and test (cabal)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run Haskell
-        uses: haskell/actions/setup@v1
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
@@ -31,10 +31,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: haskell/actions/setup@v1
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
         with:
-          ghc-version: "9.4.8"  # current version used at Chordify
+          ghc-version: "9.8.4"  # current version used at Chordify
           enable-stack: true
           stack-version: "latest"
       - run: |

--- a/redis-schema.cabal
+++ b/redis-schema.cabal
@@ -40,7 +40,7 @@ library
       OverloadedStrings
   ghc-options: -Wall
   build-depends:
-      base >=4.7 && <5
+      base >=4.18 && <5
     , binary
     , bytestring
     , containers

--- a/redis-schema.cabal
+++ b/redis-schema.cabal
@@ -45,7 +45,7 @@ library
     , bytestring
     , containers
     , exceptions
-    , hedis
+    , hedis >=0.16.1 && <0.17
     , monadIO
     , mtl
     , numeric-limits

--- a/src/Database/Redis/Schema.hs
+++ b/src/Database/Redis/Schema.hs
@@ -561,7 +561,7 @@ setIfNotExistsTTL ref val (TTLSec ttlSec) =
       , Hedis.setCondition    = Just Hedis.Nx
       , Hedis.setUnixMilliseconds = Nothing
       , Hedis.setUnixSeconds  = Nothing
-      , Hedis.setKeepTTL      = True
+      , Hedis.setKeepTTL      = False
       }
 
 deleteIfEqual :: forall ref. SimpleRef ref => ref -> ValueType ref -> RedisM (RefInstance ref) Bool

--- a/src/Database/Redis/Schema.hs
+++ b/src/Database/Redis/Schema.hs
@@ -70,6 +70,7 @@ module Database.Redis.Schema
 import GHC.Word         ( Word32  )
 import Data.Functor     ( void, (<&>) )
 import Data.Function    ( (&) )
+import Data.List.NonEmpty ( NonEmpty (..), nonEmpty )
 import Data.Time        ( UTCTime, LocalTime, Day )
 import Text.Read        ( readMaybe )
 import Data.ByteString  ( ByteString )
@@ -176,6 +177,13 @@ expect msg expected actual
 ignore :: a -> RedisM inst ()
 ignore _ = pure ()
 
+-- | @Since @hedis-0.16@ it requires non-empty list.
+-- According to Redis semantics, server will throw an error anyway.
+withNonEmptyList :: [a] -> (NonEmpty a -> RedisM inst b) -> RedisM inst b
+withNonEmptyList xs action = case nonEmpty xs of
+  Nothing -> throwMsg "Redis.withNonEmptyList: empty list"
+  Just l -> action l
+
 -- | Open a connection pool to redis
 connect :: String -> Int -> IO (Pool inst)
 connect connectionString poolSize =
@@ -253,6 +261,12 @@ runTx = Redis . Hedis.multiExec . unTx
 -- | Throw in a transaction.
 txThrow :: RedisException -> Tx inst a
 txThrow e = Tx $ pure (pure (Left e))
+
+-- | Same as 'withNonEmptyList' but for 'Tx'. It will throw an exception if provided list is empty.
+txNonEmptyList :: [a] -> (NonEmpty a -> Tx inst b) -> Tx inst b
+txNonEmptyList xs action = case nonEmpty xs of
+  Nothing -> txThrow $ UserException "txNonEmptyList: emptyList"
+  Just l -> action l
 
 -- | Embed a raw Hedis action in a 'Tx' transaction.
 txWrap :: Hedis.RedisTx (Hedis.Queued a) -> Tx inst a
@@ -344,14 +358,14 @@ class Value inst val where
       $ txWrap (Hedis.set keyBS $ toBS val)
   txValSet (SviHash keyBS hkeyBS) val =
     void
-      $ txWrap (Hedis.hset keyBS hkeyBS $ toBS val)
+      $ txWrap (Hedis.hset keyBS $ (hkeyBS, toBS val) :| [])
 
   -- | Delete a value from Redis in a transaction.
   txValDelete :: Identifier val -> Tx inst ()
 
   default txValDelete :: SimpleValue inst val => Identifier val -> Tx inst ()
-  txValDelete (SviTopLevel keyBS) = void . txWrap $ Hedis.del [keyBS]
-  txValDelete (SviHash keyBS hkeyBS) = void . txWrap $ Hedis.hdel keyBS [hkeyBS]
+  txValDelete (SviTopLevel keyBS) = void . txWrap $ Hedis.del (keyBS :| [])
+  txValDelete (SviHash keyBS hkeyBS) = void . txWrap $ Hedis.hdel keyBS (hkeyBS :| [])
 
   -- | Set time-to-live for a value in a transaction. Return 'True' if the value exists.
   txValSetTTLIfExists :: Identifier val -> TTL -> Tx inst Bool
@@ -379,7 +393,7 @@ class Value inst val where
   valSet (SviTopLevel keyBS) val =
     expect "valSet/plain" (Right Hedis.Ok) =<< Hedis.set keyBS (toBS val)
   valSet (SviHash keyBS hkeyBS) val =
-    ignore {- @Integer -} =<< expectRight "valSet/hash" =<< Hedis.hset keyBS hkeyBS (toBS val)
+    ignore {- @Integer -} =<< expectRight "valSet/hash" =<< Hedis.hset keyBS ((hkeyBS, toBS val) :| [])
       --   ^- this is Bool in some versions of Hedis and Integer in others
 
   -- | Delete a value.
@@ -387,9 +401,9 @@ class Value inst val where
 
   default valDelete :: SimpleValue inst val => Identifier val -> RedisM inst ()
   valDelete (SviTopLevel keyBS) =
-    ignore @Integer =<< expectRight "valDelete/plain" =<< Hedis.del [keyBS]
+    ignore @Integer =<< expectRight "valDelete/plain" =<< Hedis.del (keyBS :| [])
   valDelete (SviHash keyBS hkeyBS) =
-    ignore @Integer =<< expectRight "valDelete/hash" =<< Hedis.hdel keyBS [hkeyBS]
+    ignore @Integer =<< expectRight "valDelete/hash" =<< Hedis.hdel keyBS (hkeyBS :| [])
 
   -- | Set time-to-live for a value. Return 'True' if the value exists.
   valSetTTLIfExists :: Identifier val -> TTL -> RedisM inst Bool
@@ -501,12 +515,14 @@ setWithTTL ref ttl@(TTLSec ttlSec) val = case toIdentifier ref of
 incrementBy :: (SimpleRef ref, Num (ValueType ref)) => ref -> Integer -> RedisM (RefInstance ref) (ValueType ref)
 incrementBy ref val = fmap fromInteger . expectRight "incrementBy" =<< case toIdentifier ref of
   SviTopLevel keyBS -> Hedis.incrby keyBS val
-  SviHash keyBS hkeyBS -> Hedis.hincrby keyBS hkeyBS val
+  SviHash keyBS hkeyBS -> fmap (fromIntegral @Int64 @Integer)
+    <$> Hedis.hincrby keyBS hkeyBS (fromIntegral @Integer @Int64 val)
 
 txIncrementBy :: (SimpleRef ref, Num (ValueType ref)) => ref -> Integer -> Tx (RefInstance ref) (ValueType ref)
 txIncrementBy ref val = fmap fromInteger . txWrap $ case toIdentifier ref of
   SviTopLevel keyBS -> Hedis.incrby keyBS val
-  SviHash keyBS hkeyBS -> Hedis.hincrby keyBS hkeyBS val
+  SviHash keyBS hkeyBS -> fmap (fromIntegral @Int64 @Integer)
+    <$> Hedis.hincrby keyBS hkeyBS (fromIntegral @Integer @Int64 val)
 
 -- | Increment the value under the given ref.
 incrementByFloat :: (SimpleRef ref, Floating (ValueType ref)) => ref -> Double -> RedisM (RefInstance ref) (ValueType ref)
@@ -543,6 +559,9 @@ setIfNotExistsTTL ref val (TTLSec ttlSec) =
       { Hedis.setSeconds      = Just ttlSec
       , Hedis.setMilliseconds = Nothing
       , Hedis.setCondition    = Just Hedis.Nx
+      , Hedis.setUnixMilliseconds = Nothing
+      , Hedis.setUnixSeconds  = Nothing
+      , Hedis.setKeepTTL      = True
       }
 
 deleteIfEqual :: forall ref. SimpleRef ref => ref -> ValueType ref -> RedisM (RefInstance ref) Bool
@@ -824,8 +843,9 @@ instance Serializable a => Value inst [a] where
     txWrap (Hedis.lrange keyBS 0 (-1))
     & txFromBSMany
     & fmap Just
-  txValSet keyBS vs = void $ txWrap (Hedis.del [keyBS] *> Hedis.rpush keyBS (map toBS vs))
-  txValDelete keyBS = void $ txWrap (Hedis.del [keyBS])
+  txValSet keyBS vs = txNonEmptyList (map toBS vs) $ \l -> void $ txWrap
+    (Hedis.del (keyBS :| []) *> Hedis.rpush keyBS l)
+  txValDelete keyBS = void $ txWrap (Hedis.del $ keyBS :| [])
   txValSetTTLIfExists keyBS (TTLSec ttlSec) = txWrap (Hedis.expire keyBS ttlSec)
 
   valGet keyBS =
@@ -835,12 +855,13 @@ instance Serializable a => Value inst [a] where
         Left badBS -> throw $ CouldNotDecodeValue (Just badBS)
         Right vs -> pure (Just vs))
 
-  valSet keyBS vs =
-    Redis (Hedis.multiExec (Hedis.del [keyBS] *> Hedis.rpush keyBS (map toBS vs)))
+  valSet keyBS vs = withNonEmptyList (map toBS vs) $ \l ->
+    Redis (Hedis.multiExec
+      (Hedis.del (keyBS :| []) *> Hedis.rpush keyBS l))
       >>= expectTxSuccess
       >>= ignore @Integer
   valDelete keyBS =
-    Redis (Hedis.del [keyBS])
+    Redis (Hedis.del (keyBS :| []))
       >>= expectRight "valDelete/[a]"
       >>= ignore @Integer
   valSetTTLIfExists keyBS (TTLSec ttlSec) =
@@ -849,15 +870,15 @@ instance Serializable a => Value inst [a] where
 
 -- | Append to a Redis list.
 lAppend :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> [a] -> RedisM (RefInstance ref) ()
-lAppend (toIdentifier -> keyBS) vals =
-  Redis (Hedis.rpush keyBS (map toBS vals))
+lAppend (toIdentifier -> keyBS) vals = withNonEmptyList (map toBS vals) $ \l ->
+  Redis (Hedis.rpush keyBS l)
     >>= expectRight "rpush"
     >>= ignore @Integer
 
 -- | Append to a Redis list in a transaction.
 txLAppend :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> [a] -> Tx (RefInstance ref) ()
-txLAppend (toIdentifier -> keyBS) vals =
-  void . txWrap $ Hedis.rpush keyBS (map toBS vals)
+txLAppend (toIdentifier -> keyBS) vals = txNonEmptyList (map toBS vals) $ \l ->
+  void . txWrap $ Hedis.rpush keyBS l
 
 -- | Length of a Redis list
 lLength :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> RedisM (RefInstance ref) Integer
@@ -867,8 +888,8 @@ lLength (toIdentifier -> keyBS) =
 
 -- | Prepend to a Redis list.
 lPushLeft :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> [a] -> RedisM (RefInstance ref) ()
-lPushLeft (toIdentifier -> keyBS) vals =
-  Redis (Hedis.lpush keyBS (map toBS vals))
+lPushLeft (toIdentifier -> keyBS) vals = withNonEmptyList (map toBS vals) $ \l ->
+  Redis (Hedis.lpush keyBS l)
     >>= expectRight "lpush"
     >>= ignore @Integer
 
@@ -882,7 +903,7 @@ lPopRight (toIdentifier -> keyBS) =
 -- | Pop from the right, blocking.
 lPopRightBlocking :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => TTL -> ref -> RedisM (RefInstance ref) (Maybe a)
 lPopRightBlocking (TTLSec timeoutSec) (toIdentifier -> keyBS) =
-  Redis (Hedis.brpop [keyBS] timeoutSec)
+  Redis (Hedis.brpop (keyBS :| []) timeoutSec)
     >>= expectRight "brpop"
     >>= traverse (rFromBSorThrow . snd)
 
@@ -903,13 +924,10 @@ instance (Serializable a, Ord a) => Value inst (Set a) where
     & txFromBSMany
     & fmap (Just . Set.fromList)
 
-  txValSet keyBS vs =
-    void $ txWrap (
-      Hedis.del [keyBS]
-      *> Hedis.sadd keyBS (map toBS $ Set.toList vs)
-    )
+  txValSet keyBS vs = txNonEmptyList (map toBS $ Set.toList vs) $ \l ->
+    void $ txWrap (Hedis.del (keyBS :| []) *> Hedis.sadd keyBS l)
 
-  txValDelete keyBS = void $ txWrap (Hedis.del [keyBS])
+  txValDelete keyBS = void $ txWrap (Hedis.del (keyBS :| []))
   txValSetTTLIfExists keyBS (TTLSec ttlSec) = txWrap (Hedis.expire keyBS ttlSec)
 
   valGet keyBS =
@@ -919,15 +937,12 @@ instance (Serializable a, Ord a) => Value inst (Set a) where
         Left badBS -> throw $ CouldNotDecodeValue (Just badBS)
         Right vs -> pure (Just $ Set.fromList vs))
 
-  valSet keyBS vs =
-    Redis (Hedis.multiExec (
-      Hedis.del [keyBS]
-      *> Hedis.sadd keyBS (map toBS $ Set.toList vs)
-    ))
+  valSet keyBS vs = withNonEmptyList (map toBS $ Set.toList vs) $ \l ->
+    Redis (Hedis.multiExec (Hedis.del (keyBS :| []) *> Hedis.sadd keyBS l))
       >>= expectTxSuccess
       >>= ignore @Integer
 
-  valDelete keyBS = Redis (Hedis.del [keyBS])
+  valDelete keyBS = Redis (Hedis.del (keyBS :| []))
     >>= expectRight "valDelete/Set a"
     >>= ignore @Integer
 
@@ -937,29 +952,27 @@ instance (Serializable a, Ord a) => Value inst (Set a) where
 
 -- | Insert into a Redis set.
 sInsert :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> [a] -> RedisM (RefInstance ref) ()
-sInsert ref vals =
-  Redis (Hedis.sadd (toIdentifier ref) (map toBS vals))
+sInsert ref vals = withNonEmptyList (map toBS vals) $ \l ->
+  Redis (Hedis.sadd (toIdentifier ref) l)
     >>= expectRight "setInsert"
     >>= ignore @Integer
 
 -- | Insert into a Redis set in a transaction.
 txSInsert :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> [a] -> Tx (RefInstance ref) ()
-txSInsert ref vals =
-  void . txWrap
-    $ Hedis.sadd (toIdentifier ref) (map toBS vals)
+txSInsert ref vals = txNonEmptyList (map toBS vals) $ \l ->
+  void . txWrap $ Hedis.sadd (toIdentifier ref) l
 
 -- | Delete from a Redis set.
 sDelete :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> [a] -> RedisM (RefInstance ref) ()
-sDelete ref vals =
-  Redis (Hedis.srem (toIdentifier ref) (map toBS vals))
+sDelete ref vals = withNonEmptyList (map toBS vals) $ \l ->
+  Redis (Hedis.srem (toIdentifier ref) l)
     >>= expectRight "hashSetDelete"
     >>= ignore @Integer
 
 -- | Delete from a Redis set in a transaction.
 txSDelete :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> [a] -> Tx (RefInstance ref) ()
-txSDelete ref vals =
-  void . txWrap
-    $ Hedis.srem (toIdentifier ref) (map toBS vals)
+txSDelete ref vals = txNonEmptyList (map toBS vals) $ \l ->
+  void . txWrap $ Hedis.srem (toIdentifier ref) l
 
 -- | Check membership in a Redis set.
 sContains :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> a -> RedisM (RefInstance ref) Bool
@@ -1002,7 +1015,7 @@ zInsert (toIdentifier -> keyBS) vals =
 -- | Delete from a Redis sorted set
 zDelete :: forall ref a. (Ref ref, ValueType ref ~ [(Priority, a)], Serializable a) => ref -> a -> RedisM (RefInstance ref) ()
 zDelete (toIdentifier -> keyBS) val =
-  Redis (Hedis.zrem keyBS [toBS val])
+  Redis (Hedis.zrem keyBS (toBS val :| []))
     >>= expectRight "zrem"
     >>= ignore @Integer
 
@@ -1132,14 +1145,13 @@ instance (Ord k, Serializable k, Serializable v) => Value inst (Map k v) where
           . parseMap
         )
 
-  txValSet keyBS m =
-    void $ txWrap (
-      Hedis.del [keyBS]
-      *> Hedis.hmset keyBS
-        [(toBS ref, toBS val) | (ref, val) <- Map.toList m]
-    )
+  txValSet keyBS m = txNonEmptyList [(toBS ref, toBS val) | (ref, val) <- Map.toList m] $ \l ->
+      void $ txWrap (
+        Hedis.del (keyBS :| [])
+        *> Hedis.hmset keyBS l
+      )
 
-  txValDelete keyBS = void . txWrap $ Hedis.del [keyBS]
+  txValDelete keyBS = void . txWrap $ Hedis.del (keyBS :| [])
   txValSetTTLIfExists keyBS (TTLSec ttlSec) =
     txWrap $ Hedis.expire keyBS ttlSec
 
@@ -1150,17 +1162,16 @@ instance (Ord k, Serializable k, Serializable v) => Value inst (Map k v) where
         Just m -> pure (Just m)
         Nothing -> throw $ CouldNotDecodeValue Nothing
 
-  valSet keyBS m =
-    Redis (Hedis.multiExec (
-      Hedis.del [keyBS]
-      *> Hedis.hmset keyBS
-        [(toBS ref, toBS val) | (ref, val) <- Map.toList m]
-    ))
-      >>= expectTxSuccess
-      >>= expect "valSet/Map k v" Hedis.Ok
+  valSet keyBS m = withNonEmptyList [(toBS ref, toBS val) | (ref, val) <- Map.toList m] $ \l ->
+      Redis (Hedis.multiExec (
+        Hedis.del (keyBS :| [])
+        *> Hedis.hmset keyBS l
+      ))
+        >>= expectTxSuccess
+        >>= expect "valSet/Map k v" Hedis.Ok
 
   valDelete keyBS =
-    Redis (Hedis.del [keyBS])
+    Redis (Hedis.del (keyBS :| []))
       >>= expectRight "valDelete/Map k v"
       >>= ignore @Integer
 
@@ -1193,6 +1204,7 @@ instance
   , ValueType ref ~ Map k v
   , Serializable k
   , SimpleValue (RefInstance ref) v
+  , Value (RefInstance ref) v
   ) => Ref (MapItem ref k v) where
 
   type ValueType (MapItem ref k v) = v
@@ -1216,6 +1228,7 @@ instance
   , ValueType ref ~ Record fieldF
   , SimpleValue (RefInstance ref) val
   , RecordField fieldF
+  , Value (RefInstance ref) val
   ) => Ref (RecordItem ref fieldF val) where
 
   type ValueType (RecordItem ref fieldF val) = val
@@ -1253,11 +1266,11 @@ instance Value inst (Record fieldF) where
   type Identifier (Record fieldF) = ByteString
   txValGet _ = error "Record is not meant to be read"
   txValSet _ _ = error "Record is not meant to be written"
-  txValDelete keyBS = void . txWrap $ Hedis.del [keyBS]
+  txValDelete keyBS = void . txWrap $ Hedis.del (keyBS :| [])
   txValSetTTLIfExists keyBS (TTLSec ttlSec) = txWrap $ Hedis.expire keyBS ttlSec
   valGet _ = error "Record is not meant to be read"
   valSet _ _ = error "Record is not meant to be written"
-  valDelete keyBS = Hedis.del [keyBS]
+  valDelete keyBS = Hedis.del (keyBS :| [])
     >>= expectRight "valDelete/Record" >>= ignore @Integer
   valSetTTLIfExists keyBS (TTLSec ttlSec) =
     Hedis.expire keyBS ttlSec >>= expectRight "setTTLIfExists/Record"
@@ -1275,11 +1288,11 @@ instance Value inst (PubSub msg) where
   type Identifier (PubSub msg) = ByteString
   txValGet _ = error "PubSub is not meant to be read"
   txValSet _ _ = error "PubSub is not meant to be written"
-  txValDelete keyBS = void . txWrap $ Hedis.del [keyBS]
+  txValDelete keyBS = void . txWrap $ Hedis.del (keyBS :| [])
   txValSetTTLIfExists keyBS (TTLSec ttlSec) = txWrap $ Hedis.expire keyBS ttlSec
   valGet _ = error "PubSub is not meant to be read"
   valSet _ _ = error "PubSub is not meant to be written"
-  valDelete keyBS = Hedis.del [keyBS]
+  valDelete keyBS = Hedis.del (keyBS :| [])
     >>= expectRight "valDelete/PubSub" >>= ignore @Integer
   valSetTTLIfExists keyBS (TTLSec ttlSec) =
     Hedis.expire keyBS ttlSec >>= expectRight "setTTLIfExists/PubSub"

--- a/src/Database/Redis/Schema.hs
+++ b/src/Database/Redis/Schema.hs
@@ -70,7 +70,7 @@ module Database.Redis.Schema
 import GHC.Word         ( Word32  )
 import Data.Functor     ( void, (<&>) )
 import Data.Function    ( (&) )
-import Data.List.NonEmpty ( NonEmpty (..), nonEmpty )
+import Data.List.NonEmpty ( NonEmpty (..) )
 import Data.Time        ( UTCTime, LocalTime, Day )
 import Text.Read        ( readMaybe )
 import Data.ByteString  ( ByteString )
@@ -95,6 +95,7 @@ import qualified Numeric.Limits
 import qualified Database.Redis as Hedis
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy as BSL
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified System.IO.Error as IOE
@@ -177,13 +178,6 @@ expect msg expected actual
 ignore :: a -> RedisM inst ()
 ignore _ = pure ()
 
--- | @Since @hedis-0.16@ it requires non-empty list.
--- According to Redis semantics, server will throw an error anyway.
-withNonEmptyList :: [a] -> (NonEmpty a -> RedisM inst b) -> RedisM inst b
-withNonEmptyList xs action = case nonEmpty xs of
-  Nothing -> throwMsg "Redis.withNonEmptyList: empty list"
-  Just l -> action l
-
 -- | Open a connection pool to redis
 connect :: String -> Int -> IO (Pool inst)
 connect connectionString poolSize =
@@ -261,12 +255,6 @@ runTx = Redis . Hedis.multiExec . unTx
 -- | Throw in a transaction.
 txThrow :: RedisException -> Tx inst a
 txThrow e = Tx $ pure (pure (Left e))
-
--- | Same as 'withNonEmptyList' but for 'Tx'. It will throw an exception if provided list is empty.
-txNonEmptyList :: [a] -> (NonEmpty a -> Tx inst b) -> Tx inst b
-txNonEmptyList xs action = case nonEmpty xs of
-  Nothing -> txThrow $ UserException "txNonEmptyList: emptyList"
-  Just l -> action l
 
 -- | Embed a raw Hedis action in a 'Tx' transaction.
 txWrap :: Hedis.RedisTx (Hedis.Queued a) -> Tx inst a
@@ -843,8 +831,9 @@ instance Serializable a => Value inst [a] where
     txWrap (Hedis.lrange keyBS 0 (-1))
     & txFromBSMany
     & fmap Just
-  txValSet keyBS vs = txNonEmptyList (map toBS vs) $ \l -> void $ txWrap
-    (Hedis.del (keyBS :| []) *> Hedis.rpush keyBS l)
+  txValSet _ [] = txThrow $ UserException "txValSet: empty list"
+  txValSet keyBS (v : vs) = void $ txWrap
+    (Hedis.del (keyBS :| []) *> Hedis.rpush keyBS (NE.map toBS (v :| vs)))
   txValDelete keyBS = void $ txWrap (Hedis.del $ keyBS :| [])
   txValSetTTLIfExists keyBS (TTLSec ttlSec) = txWrap (Hedis.expire keyBS ttlSec)
 
@@ -855,9 +844,10 @@ instance Serializable a => Value inst [a] where
         Left badBS -> throw $ CouldNotDecodeValue (Just badBS)
         Right vs -> pure (Just vs))
 
-  valSet keyBS vs = withNonEmptyList (map toBS vs) $ \l ->
+  valSet _ [] = throwMsg "valSet: empty list"
+  valSet keyBS (v : vs) =
     Redis (Hedis.multiExec
-      (Hedis.del (keyBS :| []) *> Hedis.rpush keyBS l))
+      (Hedis.del (keyBS :| []) *> Hedis.rpush keyBS (NE.map toBS (v :| vs))))
       >>= expectTxSuccess
       >>= ignore @Integer
   valDelete keyBS =
@@ -869,16 +859,15 @@ instance Serializable a => Value inst [a] where
       >>= expectRight "valSetTTLIfExists/[a]"
 
 -- | Append to a Redis list.
-lAppend :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> [a] -> RedisM (RefInstance ref) ()
-lAppend (toIdentifier -> keyBS) vals = withNonEmptyList (map toBS vals) $ \l ->
-  Redis (Hedis.rpush keyBS l)
+lAppend :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> NonEmpty a -> RedisM (RefInstance ref) ()
+lAppend (toIdentifier -> keyBS) vals =
+  Redis (Hedis.rpush keyBS (NE.map toBS vals))
     >>= expectRight "rpush"
     >>= ignore @Integer
 
 -- | Append to a Redis list in a transaction.
-txLAppend :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> [a] -> Tx (RefInstance ref) ()
-txLAppend (toIdentifier -> keyBS) vals = txNonEmptyList (map toBS vals) $ \l ->
-  void . txWrap $ Hedis.rpush keyBS l
+txLAppend :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> NonEmpty a -> Tx (RefInstance ref) ()
+txLAppend (toIdentifier -> keyBS) vals = void . txWrap $ Hedis.rpush keyBS $ NE.map toBS vals
 
 -- | Length of a Redis list
 lLength :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> RedisM (RefInstance ref) Integer
@@ -887,9 +876,9 @@ lLength (toIdentifier -> keyBS) =
     >>= expectRight "llen"
 
 -- | Prepend to a Redis list.
-lPushLeft :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> [a] -> RedisM (RefInstance ref) ()
-lPushLeft (toIdentifier -> keyBS) vals = withNonEmptyList (map toBS vals) $ \l ->
-  Redis (Hedis.lpush keyBS l)
+lPushLeft :: forall ref a. (Ref ref, ValueType ref ~ [a], Serializable a) => ref -> NonEmpty a -> RedisM (RefInstance ref) ()
+lPushLeft (toIdentifier -> keyBS) vals =
+  Redis (Hedis.lpush keyBS (NE.map toBS vals))
     >>= expectRight "lpush"
     >>= ignore @Integer
 
@@ -924,8 +913,9 @@ instance (Serializable a, Ord a) => Value inst (Set a) where
     & txFromBSMany
     & fmap (Just . Set.fromList)
 
-  txValSet keyBS vs = txNonEmptyList (map toBS $ Set.toList vs) $ \l ->
-    void $ txWrap (Hedis.del (keyBS :| []) *> Hedis.sadd keyBS l)
+  txValSet keyBS vs = case map toBS $ Set.toList vs of
+    [] -> txThrow $ UserException "txValSet: empty set"
+    (x : xs) -> void $ txWrap (Hedis.del (keyBS :| []) *> Hedis.sadd keyBS (x :| xs))
 
   txValDelete keyBS = void $ txWrap (Hedis.del (keyBS :| []))
   txValSetTTLIfExists keyBS (TTLSec ttlSec) = txWrap (Hedis.expire keyBS ttlSec)
@@ -937,10 +927,12 @@ instance (Serializable a, Ord a) => Value inst (Set a) where
         Left badBS -> throw $ CouldNotDecodeValue (Just badBS)
         Right vs -> pure (Just $ Set.fromList vs))
 
-  valSet keyBS vs = withNonEmptyList (map toBS $ Set.toList vs) $ \l ->
-    Redis (Hedis.multiExec (Hedis.del (keyBS :| []) *> Hedis.sadd keyBS l))
-      >>= expectTxSuccess
-      >>= ignore @Integer
+  valSet keyBS vs = case (map toBS $ Set.toList vs) of
+    [] -> throwMsg "valSet: empty set"
+    (x : xs) -> 
+      Redis (Hedis.multiExec (Hedis.del (keyBS :| []) *> Hedis.sadd keyBS (x :| xs)))
+        >>= expectTxSuccess
+        >>= ignore @Integer
 
   valDelete keyBS = Redis (Hedis.del (keyBS :| []))
     >>= expectRight "valDelete/Set a"
@@ -951,28 +943,26 @@ instance (Serializable a, Ord a) => Value inst (Set a) where
       >>= expectRight "valSetTTLIfExists/Set a"
 
 -- | Insert into a Redis set.
-sInsert :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> [a] -> RedisM (RefInstance ref) ()
-sInsert ref vals = withNonEmptyList (map toBS vals) $ \l ->
-  Redis (Hedis.sadd (toIdentifier ref) l)
+sInsert :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> NonEmpty a -> RedisM (RefInstance ref) ()
+sInsert ref vals =
+  Redis (Hedis.sadd (toIdentifier ref) (NE.map toBS vals))
     >>= expectRight "setInsert"
     >>= ignore @Integer
 
 -- | Insert into a Redis set in a transaction.
-txSInsert :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> [a] -> Tx (RefInstance ref) ()
-txSInsert ref vals = txNonEmptyList (map toBS vals) $ \l ->
-  void . txWrap $ Hedis.sadd (toIdentifier ref) l
+txSInsert :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> NonEmpty a -> Tx (RefInstance ref) ()
+txSInsert ref vals = void . txWrap $ Hedis.sadd (toIdentifier ref) (NE.map toBS vals)
 
 -- | Delete from a Redis set.
-sDelete :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> [a] -> RedisM (RefInstance ref) ()
-sDelete ref vals = withNonEmptyList (map toBS vals) $ \l ->
-  Redis (Hedis.srem (toIdentifier ref) l)
+sDelete :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> NonEmpty a -> RedisM (RefInstance ref) ()
+sDelete ref vals =
+  Redis (Hedis.srem (toIdentifier ref) (NE.map toBS vals))
     >>= expectRight "hashSetDelete"
     >>= ignore @Integer
 
 -- | Delete from a Redis set in a transaction.
-txSDelete :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> [a] -> Tx (RefInstance ref) ()
-txSDelete ref vals = txNonEmptyList (map toBS vals) $ \l ->
-  void . txWrap $ Hedis.srem (toIdentifier ref) l
+txSDelete :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> NonEmpty a -> Tx (RefInstance ref) ()
+txSDelete ref vals = void . txWrap $ Hedis.srem (toIdentifier ref) (NE.map toBS vals)
 
 -- | Check membership in a Redis set.
 sContains :: forall ref a. (Ref ref, ValueType ref ~ Set a, Serializable a) => ref -> a -> RedisM (RefInstance ref) Bool
@@ -1119,9 +1109,9 @@ zScanOpts (toIdentifier -> keyBS) mMatch mCount =
   >>= expectRight "zscanOpts call"
   >>= expectRight "zscanOpts decode" . fromBSMany . map fst . snd
 
-zUnionStoreWeights :: forall ref a. (Ref ref, ValueType ref ~ [(Priority, a)], Serializable a) => ref -> [(ref, Double)] -> RedisM (RefInstance ref) ()
+zUnionStoreWeights :: forall ref a. (Ref ref, ValueType ref ~ [(Priority, a)], Serializable a) => ref -> NonEmpty (ref, Double) -> RedisM (RefInstance ref) ()
 zUnionStoreWeights (toIdentifier -> keyBS) refWithWeights =
-  Hedis.zunionstoreWeights keyBS [(toIdentifier k, d) | (k, d) <- refWithWeights] Hedis.Sum
+  Hedis.zunionstoreWeights keyBS [(toIdentifier k, d) | (k, d) <- NE.toList refWithWeights] Hedis.Sum
   >>= expectRight "zUnionStoreWeights call"
   >>= ignore @Integer
 
@@ -1145,10 +1135,12 @@ instance (Ord k, Serializable k, Serializable v) => Value inst (Map k v) where
           . parseMap
         )
 
-  txValSet keyBS m = txNonEmptyList [(toBS ref, toBS val) | (ref, val) <- Map.toList m] $ \l ->
+  txValSet keyBS m = case [(toBS ref, toBS val) | (ref, val) <- Map.toList m] of
+    [] -> txThrow $ UserException "txValSet: empty map"
+    (v : vs) -> 
       void $ txWrap (
         Hedis.del (keyBS :| [])
-        *> Hedis.hmset keyBS l
+        *> Hedis.hmset keyBS (v :| vs)
       )
 
   txValDelete keyBS = void . txWrap $ Hedis.del (keyBS :| [])
@@ -1162,10 +1154,12 @@ instance (Ord k, Serializable k, Serializable v) => Value inst (Map k v) where
         Just m -> pure (Just m)
         Nothing -> throw $ CouldNotDecodeValue Nothing
 
-  valSet keyBS m = withNonEmptyList [(toBS ref, toBS val) | (ref, val) <- Map.toList m] $ \l ->
+  valSet keyBS m = case [(toBS ref, toBS val) | (ref, val) <- Map.toList m] of
+    [] -> throwMsg "Redis.valSet: map must not be empty"
+    (x : xs) ->
       Redis (Hedis.multiExec (
         Hedis.del (keyBS :| [])
-        *> Hedis.hmset keyBS l
+        *> Hedis.hmset keyBS (x :| xs)
       ))
         >>= expectTxSuccess
         >>= expect "valSet/Map k v" Hedis.Ok

--- a/src/Database/Redis/Schema/Lock.hs
+++ b/src/Database/Redis/Schema/Lock.hs
@@ -29,12 +29,13 @@ module Database.Redis.Schema.Lock
   where
 
 import GHC.Generics
-import Data.Functor     ( void )
-import Data.Kind        ( Type )
-import Data.Maybe       ( fromMaybe )
-import Data.Time        ( NominalDiffTime, addUTCTime, getCurrentTime )
-import Data.Set         ( Set )
-import Data.ByteString  ( ByteString )
+import Data.Functor       ( void )
+import Data.List.NonEmpty ( NonEmpty (..) )
+import Data.Kind          ( Type )
+import Data.Maybe         ( fromMaybe )
+import Data.Time          ( NominalDiffTime, addUTCTime, getCurrentTime )
+import Data.Set           ( Set )
+import Data.ByteString    ( ByteString )
 import qualified Data.Set as Set
 import qualified Data.ByteString.Char8 as BS
 
@@ -339,7 +340,7 @@ shareableLockAcquire redis slp lockSharing ref = do
               -- we want to share
               -- so we can acquire
               Just Shared | lockSharing == Shared -> do
-                Redis.sInsert (lockField LockFieldOwners) [ourId]
+                Redis.sInsert (lockField LockFieldOwners) (ourId :| [])
                 return True
 
               -- can't acquire lock otherwise
@@ -384,7 +385,7 @@ shareableLockRelease redis slp ref lockSharing ourId =
             -- delete the whole lock
             then Redis.delete_ ref
             -- just remove ourselves from the list of owners
-            else Redis.sDelete (lockField LockFieldOwners) [ourId]
+            else Redis.sDelete (lockField LockFieldOwners) (ourId :| [])
   where
     lockField :: LockFieldName ty -> LockField (Redis.RefInstance ref) ty
     lockField = LockField (Redis.toIdentifier ref)

--- a/src/Database/Redis/Schema/RemoteJob.hs
+++ b/src/Database/Redis/Schema/RemoteJob.hs
@@ -36,6 +36,7 @@ module Database.Redis.Schema.RemoteJob (
 
 import Data.Binary ( decode, encode, Binary(..) )
 import Data.Bifunctor as BF ( second )
+import Data.List.NonEmpty ( NonEmpty (..) )
 import Data.Kind ( Type )
 import Data.Maybe ( isJust )
 import Data.Proxy ( Proxy(..) )
@@ -249,8 +250,8 @@ remoteJobWorker' cont wid pool logger = doHandle (Proxy @m) (Proxy @(RPC q)) $ \
         -- Update the RunningJobs queue at the start and end of this block,
         -- and keep the workerFree var up to date
         bracket_
-          (run pool (sInsert (RunningJobs @q) [(wid,job)]) >> liftIO (takeMVar workerFree))
-          (run pool (sDelete (RunningJobs @q) [(wid,job)]) >> liftIO (putMVar workerFree ())) $ do
+          (run pool (sInsert (RunningJobs @q) ((wid,job) :| [])) >> liftIO (takeMVar workerFree))
+          (run pool (sDelete (RunningJobs @q) ((wid,job) :| [])) >> liftIO (putMVar workerFree ())) $ do
             -- Call the actual handler
             resp <- fmap Right (handler (jobHandlerIdx job) (jobInput job))
                     `catchAll`
@@ -262,7 +263,7 @@ remoteJobWorker' cont wid pool logger = doHandle (Proxy @m) (Proxy @(RPC q)) $ \
                   Right b -> Right b
             run pool $ do
               let box = ResultBox @q (jobId job)
-              lPushLeft box [bso]
+              lPushLeft box (bso :| [])
               -- set ttl to ensure the data is not left behind in case of crashes,
               -- the caller should be awaiting this already, so it's either read
               -- directly or it is never read.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
-resolver: lts-21.25
+resolver: lts-22.6
 extra-deps:
   - monadIO-0.11.1.0@sha256:2407c8aee3a74f3eba897f7c87f702f502394aec8cd412f3d2334cc353f54f13,964
+  - hedis-0.16.1@sha256:3735575ffaaa28a57d04f1e9f10c230ff2be5d28765f697bc38c1f485a4ea254,7945
+  - resource-pool-0.5.0.0@sha256:10aa71ad1d064f49a74d6bd52e3b0b1d3836f50cb6d70da4ba054e0475c3060c,1618


### PR DESCRIPTION
Newer `hedis` comes with a breaking change. Contract requires `NonEmpty` list in some cases. That being said, we probably don't want to introduce a breaking change but pre-emptively throw an exception on empty list on behalf of the Redis (as it should). Later we can re-iterate on this and require non-empty list in API. 

As decided, we are moving forward with dropping GHCs from 8.10 to/including 9.4.